### PR TITLE
Trigger CI on branch 3 instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ['3']
   pull_request:
-    branches: [main]
+    branches: ['3']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Update `.github/workflows/ci.yml` to trigger on pushes/PRs against branch `3` (the SilverStripe 6 development line) instead of `main`.

## Test plan
- [ ] CI fires on this PR (it reads the workflow from the PR head, so the new trigger applies).
- [ ] Static analysis, Rector dry-run, and PHPUnit (8.3 / 8.4 / 8.5) all green.